### PR TITLE
mcrockett/fix bug with updox status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.2] - [UNRELEASED]
-### Added
-- ?
+## [1.0.2] - [2020-12-29]
+### Fixed
+- Bug where we serialized an `updox_status`
 
 ## [1.0.1] - [2020-03-27]
 ### Added

--- a/lib/updox/models/appointment.rb
+++ b/lib/updox/models/appointment.rb
@@ -37,10 +37,6 @@ module Updox
         result
       end
 
-      def as_json(args)
-        self.to_h
-      end
-
       def save(account_id: )
         self.class.sync([self], account_id: account_id)
       end

--- a/lib/updox/models/model.rb
+++ b/lib/updox/models/model.rb
@@ -7,28 +7,37 @@ module Updox
       include Hashie::Extensions::IgnoreUndeclared
       include Hashie::Extensions::IndifferentAccess
 
+      attr_writer :updox_status
+
       LIST_TYPE = 'undefined'
       LIST_NAME = 'models'
       ITEM_TYPE = 'model'
 
       property :item, required: false
       property :items, required: false
-      property :updox_status, default: {}
 
       def successful?
-        self[:updox_status].dig('successful')
+        @updox_status['successful']
       end
 
       def response_code
-        self[:updox_status].dig('responseCode')
+        @updox_status['responseCode']
       end
 
       def response_message
-        self[:updox_status].dig('responseMessage')
+        @updox_status['responseMessage']
+      end
+
+      def updox_status
+        @updox_status ||= {}
       end
 
       def error_message
         "#{response_code}: #{response_message}"
+      end
+
+      def as_json(options = nil)
+        self.to_h
       end
 
       def self.request(**kwargs)

--- a/test/updox/models/appointment_test.rb
+++ b/test/updox/models/appointment_test.rb
@@ -17,6 +17,10 @@ class AppointmentTest < Minitest::Test
         it 'has an as_json method' do
           assert_equal(appointment.to_h, appointment.as_json(takes: 1, options: 2))
         end
+
+        it 'does not include updox_status' do
+          assert_equal(false, appointment.as_json.include?('updox_status'))
+        end
       end
     end
 


### PR DESCRIPTION
** What **
- We sent across an extra field in serialized models of `updox_status` and Updox decided to get stricter with their api

** Why **
- In case they change their mind again